### PR TITLE
Reinstate user-agent header to ADDS requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ const extractData = element => {
 const fetch = async (options) => {
   try {
     const response = await superagent.get(ADDS_API_URI)
+      .set("user-agent", "node-superagent")
       .query({
         requestType: 'retrieve',
         format: 'xml',


### PR DESCRIPTION
Last Thursday, our requests to ADDS using this package started getting a `403 Forbidden` response.  Curiously, our requests that did not use this package (and still used superagent 3.8 were still working.  The only different we could see between the requests was this package was not sending a `user-agent` header, while the old version of superagent was.

Sure enough, superagent 5.1 [removed the `user-agent` header](https://github.com/visionmedia/superagent/pull/1495).  

This PR adds a `user-agent` header to the requests, which appears to fix the problem. We are still unclear on exactly what or why changes were made by ADDS to require the `user-agent`.